### PR TITLE
Exclude oneself when calculating top replies

### DIFF
--- a/tweet_display/analyse_data.py
+++ b/tweet_display/analyse_data.py
@@ -83,6 +83,7 @@ def create_tweet_types(dataframe):
     dataframe_mean_week['date'] = dataframe_mean_week['index'].astype(str)
     dataframe_mean_week = dataframe_mean_week.drop(['reply_user_name',
                                                     'retweet_user_name',
+                                                    'twitter_user_name',
                                                     'latitude',
                                                     'longitude',
                                                     'local_time',
@@ -99,6 +100,8 @@ def create_tweet_types(dataframe):
 
 
 def create_top_replies(dataframe):
+    exclude_name_list = [dataframe.iloc[0]['twitter_user_name']]
+    dataframe = dataframe[~dataframe['reply_user_name'].isin(exclude_name_list)]
     top_replies = dataframe[dataframe['reply_user_name'].isin(list(dataframe['reply_user_name'].value_counts()[:5].reset_index()['index']))]
     top_replies = top_replies.reset_index()[['reply_user_name','utc_time']]
     top_replies['utc_time'] = top_replies['utc_time'].dt.date

--- a/tweet_display/read_data.py
+++ b/tweet_display/read_data.py
@@ -101,6 +101,7 @@ def create_dataframe(tweets):
     hashtag = []
     media = []
     url = []
+    twitter_user_name = []
     retweet_user_name = []
     retweet_name = []
     reply_user_name = []
@@ -119,6 +120,7 @@ def create_dataframe(tweets):
         hashtag.append(check_hashtag(single_tweet))
         media.append(check_media(single_tweet))
         url.append(check_url(single_tweet))
+        twitter_user_name.append(single_tweet['user']['screen_name'])
         retweet = check_retweet(single_tweet)
         retweet_user_name.append(retweet[0])
         retweet_name.append(retweet[1])
@@ -139,7 +141,8 @@ def create_dataframe(tweets):
                             'retweet_name': retweet_name,
                             'reply_user_name': reply_user_name,
                             'reply_name': reply_name,
-                            'text': text
+                            'text': text,
+                            'twitter_user_name': twitter_user_name
     })
     return dataframe
 

--- a/tweet_display/tasks.py
+++ b/tweet_display/tasks.py
@@ -87,7 +87,7 @@ def import_data(oh_user_id):
         write_graph(top_replies, oh_user, 'top_replies',
                     'top users you replied to over time')
     except:
-        logger.error('tweet types crashed')
+        logger.error('top replies crashed')
     try:
         heatmap = create_heatmap(dataframe)
         write_graph(heatmap, oh_user, 'heatmap',


### PR DESCRIPTION
Add a field for twitter_user_name to dataframe. Remove tweets for which
twitter_user_name is same as reply_user_name while saving data to make
the graph. While this approach stores same twitter_user_name in each row
of dataframe, it separates parsing from plotting the graph according to
the requirement (thus allowing for flexibility later if needed). In
future if pandas supports dataframe metadata, twitter_user_name can be
stored as dataframe.twitter_user_name.

Also correct error logging statement for top replies.

Fixes #16