### PR TITLE
[WIP] Update to support new archive format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ twitter_archive/
 db.sqlite3
 dump.rdb
 .DS_Store
+data/

--- a/new_tweet_subset.js
+++ b/new_tweet_subset.js
@@ -1,0 +1,540 @@
+window.YTD.tweet.part0 = [ {
+  "retweeted" : false,
+  "source" : "<a href=\"http://tapbots.com/tweetbot\" rel=\"nofollow\">Tweetbot for iΟS</a>",
+  "entities" : {
+    "hashtags" : [ ],
+    "symbols" : [ ],
+    "user_mentions" : [ {
+      "name" : "Philipp Bayer",
+      "screen_name" : "PhilippBayer",
+      "indices" : [ "16", "29" ],
+      "id_str" : "121777206",
+      "id" : "121777206"
+    } ],
+    "urls" : [ {
+      "url" : "https://t.co/w8pz21j6Vv",
+      "expanded_url" : "https://www.goodreads.com/review/show/652888163",
+      "display_url" : "goodreads.com/review/show/65…",
+      "indices" : [ "68", "91" ]
+    } ]
+  },
+  "display_text_range" : [ "0", "91" ],
+  "favorite_count" : "1",
+  "in_reply_to_status_id_str" : "1159965221924024320",
+  "id_str" : "1159965503051485184",
+  "in_reply_to_user_id" : "14286491",
+  "truncated" : false,
+  "retweet_count" : "0",
+  "id" : "1159965503051485184",
+  "in_reply_to_status_id" : "1159965221924024320",
+  "possibly_sensitive" : false,
+  "created_at" : "Fri Aug 09 23:11:41 +0000 2019",
+  "favorited" : false,
+  "full_text" : "Read the review @PhilippBayer wrote on the mentioned autobiography. https://t.co/w8pz21j6Vv",
+  "lang" : "en",
+  "in_reply_to_screen_name" : "gedankenstuecke",
+  "in_reply_to_user_id_str" : "14286491"
+}, {
+  "retweeted" : false,
+  "source" : "<a href=\"http://tapbots.com/tweetbot\" rel=\"nofollow\">Tweetbot for iΟS</a>",
+  "entities" : {
+    "hashtags" : [ ],
+    "symbols" : [ ],
+    "user_mentions" : [ ],
+    "urls" : [ {
+      "url" : "https://t.co/Vqhq5TAdBV",
+      "expanded_url" : "https://twitter.com/DavidBLowry/status/1159836767958138880",
+      "display_url" : "twitter.com/DavidBLowry/st…",
+      "indices" : [ "114", "137" ]
+    } ]
+  },
+  "display_text_range" : [ "0", "137" ],
+  "favorite_count" : "2",
+  "id_str" : "1159965221924024320",
+  "truncated" : false,
+  "retweet_count" : "0",
+  "id" : "1159965221924024320",
+  "possibly_sensitive" : false,
+  "created_at" : "Fri Aug 09 23:10:34 +0000 2019",
+  "favorited" : false,
+  "full_text" : "He and the glowing raccoons are finally reunited, reading horoscopes and denying any link between HIV &amp; AIDS. https://t.co/Vqhq5TAdBV",
+  "lang" : "en"
+}, {
+  "retweeted" : false,
+  "source" : "<a href=\"http://tapbots.com/tweetbot\" rel=\"nofollow\">Tweetbot for iΟS</a>",
+  "entities" : {
+    "hashtags" : [ ],
+    "symbols" : [ ],
+    "user_mentions" : [ {
+      "name" : "Nazeefa \uD83C\uDF40☄",
+      "screen_name" : "NazeefaFatima",
+      "indices" : [ "0", "14" ],
+      "id_str" : "37054704",
+      "id" : "37054704"
+    } ],
+    "urls" : [ ]
+  },
+  "display_text_range" : [ "0", "57" ],
+  "favorite_count" : "1",
+  "in_reply_to_status_id_str" : "1159823677703282688",
+  "id_str" : "1159852950254227461",
+  "in_reply_to_user_id" : "37054704",
+  "truncated" : false,
+  "retweet_count" : "0",
+  "id" : "1159852950254227461",
+  "in_reply_to_status_id" : "1159823677703282688",
+  "created_at" : "Fri Aug 09 15:44:27 +0000 2019",
+  "favorited" : false,
+  "full_text" : "@NazeefaFatima It was so great to finally meet in person!",
+  "lang" : "en",
+  "in_reply_to_screen_name" : "NazeefaFatima",
+  "in_reply_to_user_id_str" : "37054704"
+}, {
+  "retweeted" : false,
+  "source" : "<a href=\"https://mobile.twitter.com\" rel=\"nofollow\">Twitter Web App</a>",
+  "entities" : {
+    "user_mentions" : [ {
+      "name" : "Philip Ellis",
+      "screen_name" : "Philip_Ellis",
+      "indices" : [ "3", "16" ],
+      "id_str" : "222444337",
+      "id" : "222444337"
+    } ],
+    "urls" : [ ],
+    "symbols" : [ ],
+    "media" : [ {
+      "expanded_url" : "https://twitter.com/zbgolia/status/1154777994252161026/video/1",
+      "source_status_id" : "1154777994252161026",
+      "indices" : [ "88", "111" ],
+      "url" : "https://t.co/kiSlwXQ9Fn",
+      "media_url" : "http://pbs.twimg.com/ext_tw_video_thumb/1154777848395304961/pu/img/DCzgIYqzvou0VeLs.jpg",
+      "id_str" : "1154777848395304961",
+      "source_user_id" : "259113321",
+      "id" : "1154777848395304961",
+      "media_url_https" : "https://pbs.twimg.com/ext_tw_video_thumb/1154777848395304961/pu/img/DCzgIYqzvou0VeLs.jpg",
+      "source_user_id_str" : "259113321",
+      "sizes" : {
+        "thumb" : {
+          "w" : "150",
+          "h" : "150",
+          "resize" : "crop"
+        },
+        "medium" : {
+          "w" : "1200",
+          "h" : "675",
+          "resize" : "fit"
+        },
+        "small" : {
+          "w" : "680",
+          "h" : "383",
+          "resize" : "fit"
+        },
+        "large" : {
+          "w" : "1280",
+          "h" : "720",
+          "resize" : "fit"
+        }
+      },
+      "type" : "photo",
+      "source_status_id_str" : "1154777994252161026",
+      "display_url" : "pic.twitter.com/kiSlwXQ9Fn"
+    } ],
+    "hashtags" : [ ]
+  },
+  "display_text_range" : [ "0", "111" ],
+  "favorite_count" : "0",
+  "id_str" : "1159146575622475776",
+  "truncated" : false,
+  "retweet_count" : "0",
+  "id" : "1159146575622475776",
+  "possibly_sensitive" : false,
+  "created_at" : "Wed Aug 07 16:57:34 +0000 2019",
+  "favorited" : false,
+  "full_text" : "RT @Philip_Ellis: [JOB INTERVIEW]\n\nInterviewer: Do you have any questions for us?\n\nMe:  https://t.co/kiSlwXQ9Fn",
+  "lang" : "en",
+  "extended_entities" : {
+    "media" : [ {
+      "expanded_url" : "https://twitter.com/zbgolia/status/1154777994252161026/video/1",
+      "source_status_id" : "1154777994252161026",
+      "indices" : [ "88", "111" ],
+      "url" : "https://t.co/kiSlwXQ9Fn",
+      "media_url" : "http://pbs.twimg.com/ext_tw_video_thumb/1154777848395304961/pu/img/DCzgIYqzvou0VeLs.jpg",
+      "id_str" : "1154777848395304961",
+      "video_info" : {
+        "aspect_ratio" : [ "16", "9" ],
+        "duration_millis" : "45412",
+        "variants" : [ {
+          "bitrate" : "256000",
+          "content_type" : "video/mp4",
+          "url" : "https://video.twimg.com/ext_tw_video/1154777848395304961/pu/vid/480x270/9dXRMkihwUJrcedP.mp4?tag=10"
+        }, {
+          "bitrate" : "832000",
+          "content_type" : "video/mp4",
+          "url" : "https://video.twimg.com/ext_tw_video/1154777848395304961/pu/vid/640x360/XI7BsQJUDBaKeBz9.mp4?tag=10"
+        }, {
+          "content_type" : "application/x-mpegURL",
+          "url" : "https://video.twimg.com/ext_tw_video/1154777848395304961/pu/pl/EzF1MVQbpeN4oXWg.m3u8?tag=10"
+        }, {
+          "bitrate" : "2176000",
+          "content_type" : "video/mp4",
+          "url" : "https://video.twimg.com/ext_tw_video/1154777848395304961/pu/vid/1280x720/g60m28vGjo1uKFrj.mp4?tag=10"
+        } ]
+      },
+      "source_user_id" : "259113321",
+      "additional_media_info" : {
+        "monetizable" : false
+      },
+      "id" : "1154777848395304961",
+      "media_url_https" : "https://pbs.twimg.com/ext_tw_video_thumb/1154777848395304961/pu/img/DCzgIYqzvou0VeLs.jpg",
+      "source_user_id_str" : "259113321",
+      "sizes" : {
+        "thumb" : {
+          "w" : "150",
+          "h" : "150",
+          "resize" : "crop"
+        },
+        "medium" : {
+          "w" : "1200",
+          "h" : "675",
+          "resize" : "fit"
+        },
+        "small" : {
+          "w" : "680",
+          "h" : "383",
+          "resize" : "fit"
+        },
+        "large" : {
+          "w" : "1280",
+          "h" : "720",
+          "resize" : "fit"
+        }
+      },
+      "type" : "video",
+      "source_status_id_str" : "1154777994252161026",
+      "display_url" : "pic.twitter.com/kiSlwXQ9Fn"
+    } ]
+  }
+}, {
+  "retweeted" : false,
+  "source" : "<a href=\"http://tapbots.com/tweetbot\" rel=\"nofollow\">Tweetbot for iΟS</a>",
+  "entities" : {
+    "hashtags" : [ ],
+    "symbols" : [ ],
+    "user_mentions" : [ {
+      "name" : "liubov",
+      "screen_name" : "luyibov",
+      "indices" : [ "0", "8" ],
+      "id_str" : "2889619139",
+      "id" : "2889619139"
+    }, {
+      "name" : "Jake Wintermute",
+      "screen_name" : "SynBio1",
+      "indices" : [ "9", "17" ],
+      "id_str" : "2570913493",
+      "id" : "2570913493"
+    }, {
+      "name" : "marc santolini",
+      "screen_name" : "msantolini",
+      "indices" : [ "18", "29" ],
+      "id_str" : "299603744",
+      "id" : "299603744"
+    }, {
+      "name" : "Roberto Toro",
+      "screen_name" : "R3RT0",
+      "indices" : [ "30", "36" ],
+      "id_str" : "2231179117",
+      "id" : "2231179117"
+    }, {
+      "name" : "katja heuer",
+      "screen_name" : "katjaQheuer",
+      "indices" : [ "37", "49" ],
+      "id_str" : "2981013099",
+      "id" : "2981013099"
+    }, {
+      "name" : "Jon Tennant",
+      "screen_name" : "Protohedgehog",
+      "indices" : [ "50", "64" ],
+      "id_str" : "352650591",
+      "id" : "352650591"
+    } ],
+    "urls" : [ ]
+  },
+  "display_text_range" : [ "0", "126" ],
+  "favorite_count" : "3",
+  "in_reply_to_status_id_str" : "1159132637795160069",
+  "id_str" : "1159140448377724929",
+  "in_reply_to_user_id" : "2889619139",
+  "truncated" : false,
+  "retweet_count" : "0",
+  "id" : "1159140448377724929",
+  "in_reply_to_status_id" : "1159132637795160069",
+  "created_at" : "Wed Aug 07 16:33:13 +0000 2019",
+  "favorited" : false,
+  "full_text" : "@luyibov @SynBio1 @msantolini @R3RT0 @katjaQheuer @Protohedgehog I’m not an expert. But I think these are called “stripes”. :p",
+  "lang" : "en",
+  "in_reply_to_screen_name" : "luyibov",
+  "in_reply_to_user_id_str" : "2889619139"
+}, {
+  "retweeted" : false,
+  "source" : "<a href=\"http://tapbots.com/tweetbot\" rel=\"nofollow\">Tweetbot for iΟS</a>",
+  "entities" : {
+    "hashtags" : [ ],
+    "symbols" : [ ],
+    "user_mentions" : [ {
+      "name" : "Bastian Greshake Tzovaras",
+      "screen_name" : "gedankenstuecke",
+      "indices" : [ "3", "19" ],
+      "id_str" : "14286491",
+      "id" : "14286491"
+    } ],
+    "urls" : [ {
+      "url" : "https://t.co/Xq0JEgsRhW",
+      "expanded_url" : "https://twitter.com/Michael__Rera/status/1158374078996242432",
+      "display_url" : "twitter.com/Michael__Rera/…",
+      "indices" : [ "76", "99" ]
+    } ]
+  },
+  "display_text_range" : [ "0", "99" ],
+  "favorite_count" : "0",
+  "id_str" : "1159080024080887809",
+  "truncated" : false,
+  "retweet_count" : "0",
+  "id" : "1159080024080887809",
+  "possibly_sensitive" : false,
+  "created_at" : "Wed Aug 07 12:33:07 +0000 2019",
+  "favorited" : false,
+  "full_text" : "RT @gedankenstuecke: That would be me, looking for an apartment in Paris. \uD83D\uDE00 https://t.co/Xq0JEgsRhW",
+  "lang" : "en"
+}, {
+  "retweeted" : false,
+  "source" : "<a href=\"http://tapbots.com/tweetbot\" rel=\"nofollow\">Tweetbot for iΟS</a>",
+  "entities" : {
+    "hashtags" : [ ],
+    "symbols" : [ ],
+    "user_mentions" : [ {
+      "name" : "marc santolini",
+      "screen_name" : "msantolini",
+      "indices" : [ "0", "11" ],
+      "id_str" : "299603744",
+      "id" : "299603744"
+    }, {
+      "name" : "Jon Tennant",
+      "screen_name" : "Protohedgehog",
+      "indices" : [ "12", "26" ],
+      "id_str" : "352650591",
+      "id" : "352650591"
+    } ],
+    "urls" : [ ]
+  },
+  "display_text_range" : [ "0", "75" ],
+  "favorite_count" : "0",
+  "in_reply_to_status_id_str" : "1158848834556051456",
+  "id_str" : "1158849711681523713",
+  "in_reply_to_user_id" : "299603744",
+  "truncated" : false,
+  "retweet_count" : "0",
+  "id" : "1158849711681523713",
+  "in_reply_to_status_id" : "1158848834556051456",
+  "created_at" : "Tue Aug 06 21:17:56 +0000 2019",
+  "favorited" : false,
+  "full_text" : "@msantolini @Protohedgehog I should have put the scare quotes: “Restaurant”",
+  "lang" : "en",
+  "in_reply_to_screen_name" : "msantolini",
+  "in_reply_to_user_id_str" : "299603744"
+}, {
+  "retweeted" : false,
+  "source" : "<a href=\"http://tapbots.com/tweetbot\" rel=\"nofollow\">Tweetbot for iΟS</a>",
+  "entities" : {
+    "hashtags" : [ ],
+    "symbols" : [ ],
+    "user_mentions" : [ {
+      "name" : "marc santolini",
+      "screen_name" : "msantolini",
+      "indices" : [ "0", "11" ],
+      "id_str" : "299603744",
+      "id" : "299603744"
+    }, {
+      "name" : "Jon Tennant",
+      "screen_name" : "Protohedgehog",
+      "indices" : [ "12", "26" ],
+      "id_str" : "352650591",
+      "id" : "352650591"
+    } ],
+    "urls" : [ ]
+  },
+  "display_text_range" : [ "0", "107" ],
+  "favorite_count" : "4",
+  "in_reply_to_status_id_str" : "1158836352387100677",
+  "id_str" : "1158836779841150978",
+  "in_reply_to_user_id" : "299603744",
+  "truncated" : false,
+  "retweet_count" : "0",
+  "id" : "1158836779841150978",
+  "in_reply_to_status_id" : "1158836352387100677",
+  "created_at" : "Tue Aug 06 20:26:33 +0000 2019",
+  "favorited" : false,
+  "full_text" : "@msantolini @Protohedgehog Yep, traditionally the only vegetarian thing you can eat in German restaurants \uD83D\uDE02",
+  "lang" : "en",
+  "in_reply_to_screen_name" : "msantolini",
+  "in_reply_to_user_id_str" : "299603744"
+}, {
+  "retweeted" : false,
+  "source" : "<a href=\"http://tapbots.com/tweetbot\" rel=\"nofollow\">Tweetbot for iΟS</a>",
+  "entities" : {
+    "hashtags" : [ ],
+    "symbols" : [ ],
+    "user_mentions" : [ {
+      "name" : "Michael Rera",
+      "screen_name" : "Michael__Rera",
+      "indices" : [ "0", "14" ],
+      "id_str" : "4075485214",
+      "id" : "4075485214"
+    }, {
+      "name" : "KIEZ Bistro Allemand",
+      "screen_name" : "KIEZ_Bistro",
+      "indices" : [ "15", "27" ],
+      "id_str" : "2514706255",
+      "id" : "2514706255"
+    } ],
+    "urls" : [ ]
+  },
+  "display_text_range" : [ "0", "177" ],
+  "favorite_count" : "1",
+  "in_reply_to_status_id_str" : "1158835594744799239",
+  "id_str" : "1158836067337940992",
+  "in_reply_to_user_id" : "4075485214",
+  "truncated" : false,
+  "retweet_count" : "1",
+  "id" : "1158836067337940992",
+  "in_reply_to_status_id" : "1158835594744799239",
+  "created_at" : "Tue Aug 06 20:23:43 +0000 2019",
+  "favorited" : false,
+  "full_text" : "@Michael__Rera @KIEZ_Bistro In good German tradition we were called ‘boring people’ (Langweiler) all evening for eating the vegetarian version of Käsespätzle. Would go again! :D",
+  "lang" : "en",
+  "in_reply_to_screen_name" : "Michael__Rera",
+  "in_reply_to_user_id_str" : "4075485214"
+}, {
+  "retweeted" : false,
+  "source" : "<a href=\"http://tapbots.com/tweetbot\" rel=\"nofollow\">Tweetbot for iΟS</a>",
+  "entities" : {
+    "user_mentions" : [ {
+      "name" : "Michael Rera",
+      "screen_name" : "Michael__Rera",
+      "indices" : [ "5", "19" ],
+      "id_str" : "4075485214",
+      "id" : "4075485214"
+    } ],
+    "urls" : [ ],
+    "symbols" : [ ],
+    "media" : [ {
+      "expanded_url" : "https://twitter.com/gedankenstuecke/status/1158806049874436096/photo/1",
+      "indices" : [ "100", "123" ],
+      "url" : "https://t.co/UYfuNLdOmD",
+      "media_url" : "http://pbs.twimg.com/media/EBTn72vWsAA9L4H.jpg",
+      "id_str" : "1158806019633491968",
+      "id" : "1158806019633491968",
+      "media_url_https" : "https://pbs.twimg.com/media/EBTn72vWsAA9L4H.jpg",
+      "sizes" : {
+        "thumb" : {
+          "w" : "150",
+          "h" : "150",
+          "resize" : "crop"
+        },
+        "medium" : {
+          "w" : "1200",
+          "h" : "900",
+          "resize" : "fit"
+        },
+        "small" : {
+          "w" : "680",
+          "h" : "510",
+          "resize" : "fit"
+        },
+        "large" : {
+          "w" : "2048",
+          "h" : "1536",
+          "resize" : "fit"
+        }
+      },
+      "type" : "photo",
+      "display_url" : "pic.twitter.com/UYfuNLdOmD"
+    } ],
+    "hashtags" : [ ]
+  },
+  "display_text_range" : [ "0", "123" ],
+  "favorite_count" : "4",
+  "id_str" : "1158806049874436096",
+  "truncated" : false,
+  "retweet_count" : "1",
+  "id" : "1158806049874436096",
+  "possibly_sensitive" : false,
+  "created_at" : "Tue Aug 06 18:24:26 +0000 2019",
+  "favorited" : false,
+  "full_text" : "When @Michael__Rera picks where you should go for dinner and he directs you to a German beer place. https://t.co/UYfuNLdOmD",
+  "lang" : "en",
+  "extended_entities" : {
+    "media" : [ {
+      "expanded_url" : "https://twitter.com/gedankenstuecke/status/1158806049874436096/photo/1",
+      "indices" : [ "100", "123" ],
+      "url" : "https://t.co/UYfuNLdOmD",
+      "media_url" : "http://pbs.twimg.com/media/EBTn72vWsAA9L4H.jpg",
+      "id_str" : "1158806019633491968",
+      "id" : "1158806019633491968",
+      "media_url_https" : "https://pbs.twimg.com/media/EBTn72vWsAA9L4H.jpg",
+      "sizes" : {
+        "thumb" : {
+          "w" : "150",
+          "h" : "150",
+          "resize" : "crop"
+        },
+        "medium" : {
+          "w" : "1200",
+          "h" : "900",
+          "resize" : "fit"
+        },
+        "small" : {
+          "w" : "680",
+          "h" : "510",
+          "resize" : "fit"
+        },
+        "large" : {
+          "w" : "2048",
+          "h" : "1536",
+          "resize" : "fit"
+        }
+      },
+      "type" : "photo",
+      "display_url" : "pic.twitter.com/UYfuNLdOmD"
+    } ]
+  }
+}, {
+  "retweeted" : false,
+  "source" : "<a href=\"https://tapbots.com/software/tweetbot/mac\" rel=\"nofollow\">Tweetbot for Mac</a>",
+  "entities" : {
+    "hashtags" : [ ],
+    "symbols" : [ ],
+    "user_mentions" : [ {
+      "name" : "Hervé Ménager",
+      "screen_name" : "rvmngr",
+      "indices" : [ "0", "7" ],
+      "id_str" : "632591287",
+      "id" : "632591287"
+    } ],
+    "urls" : [ ]
+  },
+  "display_text_range" : [ "0", "32" ],
+  "favorite_count" : "1",
+  "in_reply_to_status_id_str" : "1158467245313581056",
+  "id_str" : "1158520189102825475",
+  "in_reply_to_user_id" : "632591287",
+  "truncated" : false,
+  "retweet_count" : "0",
+  "id" : "1158520189102825475",
+  "in_reply_to_status_id" : "1158467245313581056",
+  "created_at" : "Mon Aug 05 23:28:32 +0000 2019",
+  "favorited" : false,
+  "full_text" : "@rvmngr Awesome, thanks so much!",
+  "lang" : "en",
+  "in_reply_to_screen_name" : "rvmngr",
+  "in_reply_to_user_id_str" : "632591287"
+}]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ timezonefinder==2.1.2
 geojson==2.3.0
 arrow==0.12.0
 kombu==4.1.0
+ijson==2.4

--- a/tweet_display/analyse_data.py
+++ b/tweet_display/analyse_data.py
@@ -95,7 +95,6 @@ def create_tweet_types(dataframe):
     dataframe_mean_week['date'] = dataframe_mean_week['index'].astype(str)
     dataframe_mean_week = dataframe_mean_week.drop(['reply_user_name',
                                                     'retweet_user_name',
-                                                    'twitter_user_name',
                                                     'latitude',
                                                     'longitude',
                                                     'local_time',
@@ -112,9 +111,6 @@ def create_tweet_types(dataframe):
 
 
 def create_top_replies(dataframe):
-    exclude_name_list = [dataframe.iloc[0]['twitter_user_name']]
-    dataframe = dataframe[~dataframe['reply_user_name'].isin(
-        exclude_name_list)]
     top_replies = dataframe[dataframe['reply_user_name'].isin(
         list(dataframe['reply_user_name'].value_counts()[:5].reset_index()['index']))]
     top_replies = top_replies.reset_index()[['reply_user_name', 'utc_time']]

--- a/tweet_display/read_data.py
+++ b/tweet_display/read_data.py
@@ -40,11 +40,12 @@ def check_retweet(single_tweet):
     return name & user name of the RT'd user.
     otherwise just return nones
     '''
-    if single_tweet['full_text'].startswith("RT @"):
-        if len(single_tweet['entities']['user_mentions']) > 0:
-            return (
-                single_tweet['entities']['user_mentions'][0]['screen_name'],
-                single_tweet['entities']['user_mentions'][0]['name'],)
+    if 'full_text' in single_tweet.keys():
+        if single_tweet['full_text'].startswith("RT @"):
+            if len(single_tweet['entities']['user_mentions']) > 0:
+                return (
+                  single_tweet['entities']['user_mentions'][0]['screen_name'],
+                  single_tweet['entities']['user_mentions'][0]['name'])
     if 'retweeted_status' in single_tweet.keys():
         return (single_tweet['retweeted_status']['user']['screen_name'],
                 single_tweet['retweeted_status']['user']['name'])
@@ -150,7 +151,10 @@ def create_dataframe(tweets):
         reply = check_reply_to(single_tweet)
         reply_user_name.append(reply[0])
         reply_name.append(reply[1])
-        text.append(single_tweet['full_text'])
+        if 'full_text' in single_tweet.keys():
+            text.append(single_tweet['full_text'])
+        else:
+            text.append(single_tweet['text'])
     # convert the whole shebang into a pandas dataframe
     dataframe = pd.DataFrame(data={
                             'utc_time': utc_time,

--- a/tweet_display/read_data.py
+++ b/tweet_display/read_data.py
@@ -23,7 +23,10 @@ def check_hashtag(single_tweet):
 
 def check_media(single_tweet):
     '''check whether tweet has any media attached'''
-    return len(single_tweet['entities']['media']) > 0
+    if 'media' in single_tweet['entities'].keys():
+        return len(single_tweet['entities']['media']) > 0
+    else:
+        return False
 
 
 def check_url(single_tweet):
@@ -37,11 +40,15 @@ def check_retweet(single_tweet):
     return name & user name of the RT'd user.
     otherwise just return nones
     '''
+    if single_tweet['full_text'].startswith("RT @"):
+        if len(single_tweet['entities']['user_mentions']) > 0:
+            return (
+                single_tweet['entities']['user_mentions'][0]['screen_name'],
+                single_tweet['entities']['user_mentions'][0]['name'],)
     if 'retweeted_status' in single_tweet.keys():
         return (single_tweet['retweeted_status']['user']['screen_name'],
                 single_tweet['retweeted_status']['user']['name'])
-    else:
-        return (None, None)
+    return (None, None)
 
 
 def check_coordinates(single_tweet):
@@ -50,9 +57,12 @@ def check_coordinates(single_tweet):
     if yes return the coordinates
     otherwise just return nones
     '''
-    if 'coordinates' in single_tweet['geo'].keys():
-        return (single_tweet['geo']['coordinates'][0],
-                single_tweet['geo']['coordinates'][1])
+    if 'geo' in single_tweet.keys():
+        if 'coordinates' in single_tweet['geo'].keys():
+            return (float(single_tweet['geo']['coordinates'][0]),
+                    float(single_tweet['geo']['coordinates'][1]))
+        else:
+            return (None, None)
     else:
         return (None, None)
 
@@ -101,7 +111,6 @@ def create_dataframe(tweets):
     hashtag = []
     media = []
     url = []
-    twitter_user_name = []
     retweet_user_name = []
     retweet_name = []
     reply_user_name = []
@@ -109,26 +118,38 @@ def create_dataframe(tweets):
     text = []
     # iterate over all tweets and extract data
     for single_tweet in tweets:
-        utc_time.append(datetime.datetime.strptime(single_tweet['created_at'],
-                                                   '%Y-%m-%d %H:%M:%S %z'))
+        try:
+            utc_time.append(
+                datetime.datetime.strptime(
+                    single_tweet['created_at'],
+                    '%a %b %d %H:%M:%S %z %Y'))
+        except ValueError:
+            utc_time.append(
+                datetime.datetime.strptime(
+                    single_tweet['created_at'],
+                    '%Y-%m-%d %H:%M:%S %z'))
         coordinates = check_coordinates(single_tweet)
         latitude.append(coordinates[0])
         longitude.append(coordinates[1])
-        creation_time = datetime.datetime.strptime(single_tweet['created_at'],
-                                                   '%Y-%m-%d %H:%M:%S %z')
+        try:
+            creation_time = datetime.datetime.strptime(
+                    single_tweet['created_at'],
+                    '%a %b %d %H:%M:%S %z %Y')
+        except ValueError:
+            creation_time = datetime.datetime.strptime(single_tweet['created_at'],
+                                                       '%Y-%m-%d %H:%M:%S %z')
         converted_time = convert_time(coordinates, creation_time)
         local_time.append(converted_time)
         hashtag.append(check_hashtag(single_tweet))
         media.append(check_media(single_tweet))
         url.append(check_url(single_tweet))
-        twitter_user_name.append(single_tweet['user']['screen_name'])
         retweet = check_retweet(single_tweet)
         retweet_user_name.append(retweet[0])
         retweet_name.append(retweet[1])
         reply = check_reply_to(single_tweet)
         reply_user_name.append(reply[0])
         reply_name.append(reply[1])
-        text.append(single_tweet['text'])
+        text.append(single_tweet['full_text'])
     # convert the whole shebang into a pandas dataframe
     dataframe = pd.DataFrame(data={
                             'utc_time': utc_time,
@@ -143,7 +164,6 @@ def create_dataframe(tweets):
                             'reply_user_name': reply_user_name,
                             'reply_name': reply_name,
                             'text': text,
-                            'twitter_user_name': twitter_user_name
     })
     return dataframe
 
@@ -199,15 +219,19 @@ def read_files(zf, filetype):
     correct_json = tempfile.NamedTemporaryFile(mode='w')
     correct_json.write(tweet_string)
     correct_json.flush()
-    objects = ijson.items(open(correct_json.name, 'r'), 'item')
-    for o in objects:
-        print(o)
+    tweets = ijson.items(open(correct_json.name, 'r'), 'item')
+    data_frame = create_dataframe(tweets)
+    return [data_frame]
 
 
 def create_main_dataframe(zip_url='http://ruleofthirds.de/test_archive.zip'):
     if zip_url.startswith('http'):
         print('reading zip file from web')
         zip_file, filetype = fetch_zip_file(zip_url)
+    elif os.path.isfile(zip_url):
+        print('reading zip file from disk')
+        zip_file = zipfile.ZipFile(zip_url)
+        filetype = 'zipped'
     else:
         raise ValueError('zip_url is not an URL nor a file in disk')
 

--- a/tweet_display/read_data.py
+++ b/tweet_display/read_data.py
@@ -8,7 +8,7 @@ import ijson
 import io
 import pandas as pd
 import requests
-
+import os
 
 # tzwhere_ = tzwhere.tzwhere()
 tzf = TimezoneFinder()
@@ -136,8 +136,9 @@ def create_dataframe(tweets):
                     single_tweet['created_at'],
                     '%a %b %d %H:%M:%S %z %Y')
         except ValueError:
-            creation_time = datetime.datetime.strptime(single_tweet['created_at'],
-                                                       '%Y-%m-%d %H:%M:%S %z')
+            creation_time = datetime.datetime.strptime(
+                single_tweet['created_at'],
+                '%Y-%m-%d %H:%M:%S %z')
         converted_time = convert_time(coordinates, creation_time)
         local_time.append(converted_time)
         hashtag.append(check_hashtag(single_tweet))

--- a/tweet_display/tasks.py
+++ b/tweet_display/tasks.py
@@ -77,18 +77,18 @@ def import_data(oh_user_id):
         write_graph(hourly_stats, oh_user, 'hourly_tweets', 'tweets per hour')
     except:
         logger.error('hourly stats crashed')
-    #try:
-    tweet_types = create_tweet_types(dataframe)
-    write_graph(tweet_types, oh_user, 'tweet_types',
-                'tweet types over time')
-    #except:
-    #    logger.error('tweet types crashed')
-    #try:
-    top_replies = create_top_replies(dataframe)
-    write_graph(top_replies, oh_user, 'top_replies',
-                'top users you replied to over time')
-    #except:
-    #    logger.error('top replies crashed')
+    try:
+        tweet_types = create_tweet_types(dataframe)
+        write_graph(tweet_types, oh_user, 'tweet_types',
+                    'tweet types over time')
+    except:
+        logger.error('tweet types crashed')
+    try:
+        top_replies = create_top_replies(dataframe)
+        write_graph(top_replies, oh_user, 'top_replies',
+                    'top users you replied to over time')
+    except:
+        logger.error('top replies crashed')
     try:
         heatmap = create_heatmap(dataframe)
         write_graph(heatmap, oh_user, 'heatmap',

--- a/tweet_display/tasks.py
+++ b/tweet_display/tasks.py
@@ -61,7 +61,6 @@ def import_data(oh_user_id):
     oh_user = OpenHumansMember.objects.get(oh_id=oh_user_id)
     delete_old_data(oh_user_id)
     dataframe = create_main_dataframe(url)
-    print(dataframe.head())
     try:
         retweet_gender = predict_gender(dataframe, 'retweet_name', '180d')
         write_graph(retweet_gender, oh_user, 'gender_rt', 'retweets by gender')

--- a/tweet_display/tasks.py
+++ b/tweet_display/tasks.py
@@ -61,6 +61,7 @@ def import_data(oh_user_id):
     oh_user = OpenHumansMember.objects.get(oh_id=oh_user_id)
     delete_old_data(oh_user_id)
     dataframe = create_main_dataframe(url)
+    print(dataframe.head())
     try:
         retweet_gender = predict_gender(dataframe, 'retweet_name', '180d')
         write_graph(retweet_gender, oh_user, 'gender_rt', 'retweets by gender')
@@ -76,18 +77,18 @@ def import_data(oh_user_id):
         write_graph(hourly_stats, oh_user, 'hourly_tweets', 'tweets per hour')
     except:
         logger.error('hourly stats crashed')
-    try:
-        tweet_types = create_tweet_types(dataframe)
-        write_graph(tweet_types, oh_user, 'tweet_types',
-                    'tweet types over time')
-    except:
-        logger.error('tweet types crashed')
-    try:
-        top_replies = create_top_replies(dataframe)
-        write_graph(top_replies, oh_user, 'top_replies',
-                    'top users you replied to over time')
-    except:
-        logger.error('top replies crashed')
+    #try:
+    tweet_types = create_tweet_types(dataframe)
+    write_graph(tweet_types, oh_user, 'tweet_types',
+                'tweet types over time')
+    #except:
+    #    logger.error('tweet types crashed')
+    #try:
+    top_replies = create_top_replies(dataframe)
+    write_graph(top_replies, oh_user, 'top_replies',
+                'top users you replied to over time')
+    #except:
+    #    logger.error('top replies crashed')
     try:
         heatmap = create_heatmap(dataframe)
         write_graph(heatmap, oh_user, 'heatmap',

--- a/tweet_display/tests/tests_data.py
+++ b/tweet_display/tests/tests_data.py
@@ -2,7 +2,7 @@ import os
 
 from django.test import TestCase
 
-from ..read_data import create_main_dataframe
+from ..read_data import create_main_dataframe, read_files
 from ..analyse_data import create_heatmap, \
     create_hourly_stats, \
     create_overall, \
@@ -21,19 +21,37 @@ class DataTestCase(TestCase):
         file_name = 'test_archive_2016_2017_2_months.zip'
         current_dir = os.path.dirname(os.path.realpath('__file__'))
         test_file = os.path.join(current_dir, file_name)
+
+        new_filename = 'new_tweet_subset.js'
+        new_test_file = os.path.join(current_dir, new_filename)
+
         self.df = create_main_dataframe(test_file)
+        self.new_df = read_files(open(new_test_file, 'r'), 'json')[0]
+        self.new_df = self.new_df.sort_values('utc_time', ascending=False)
+        self.new_df = self.new_df.set_index('utc_time')
+        self.new_df = self.new_df.replace(to_replace={
+                                        'url': {False: None},
+                                        'hashtag': {False: None},
+                                        'media': {False: None}
+                                        })
 
     def test_create_hourly_stats(self):
         stats = create_hourly_stats(self.df)
         self.assertEquals(stats.shape, (20, 4))
 
+
     def test_create_heatmap(self):
         heatmap = create_heatmap(self.df)
         self.assertEquals(heatmap.shape, (469, 2))
+        new_heatmap = create_heatmap(self.new_df)
+        self.assertEquals(new_heatmap.shape, (0, 2))
+
 
     def test_create_overall(self):
         overall = create_overall(self.df)
         self.assertEquals(overall.shape, (62, 2))
+        new_overall = create_overall(self.new_df)
+        self.assertEquals(new_overall.shape, (4, 2))
 
     def test_create_timeline(self):
         timeline = create_timeline(self.df)

--- a/twitteranalyser/templates/twitteranalyser/about.html
+++ b/twitteranalyser/templates/twitteranalyser/about.html
@@ -15,7 +15,7 @@
           </div>
           <div class="col-md-7">
             <p>
-            The site is hosted and run by <strong><a href="http://www.ruleofthirds.de">
+            The site is hosted and run by <strong><a href="http://www.tzovar.as">
               Bastian Greshake Tzovaras</a></strong>. When he is not diving in the data of Twitter archives
               he is tweeting himself at <strong>
                 <a href="https://twitter.com/gedankenstuecke">@gedankenstuecke</a></strong>,

--- a/users/templates/users/complete.html
+++ b/users/templates/users/complete.html
@@ -8,19 +8,30 @@
       </p>
       <div class="row">
         <div class="col-md-6">
-          <p>
-            To get your Twitter archive file&hellip;
-          </p>
+          <h3>
+            To get your Twitter archive &hellip;
+          </h3>
           <ol>
-            <li>Go to your <b><a href="https://twitter.com/settings/account">Twitter account settings</a></b></li>
-            <li><b>Scroll to the bottom</b> and click <b>"Request your archive"</b></li>
-            <li><b>Check your email</b> &ndash; you should soon get a <b>download link</b>!</li>
+            <li>Go to your <b><a href="https://twitter.com/settings/your_twitter_data">Twitter Data</a> page</b></li>
+            <li><b>Enter your password and request your data</b></li>
+            <li><b>Check your email</b> &ndash; you should get a <b>download link</b> for your data!</li>
           </ol>
-          <p>
-            Once you've downloaded your archive, you can upload it to your Open
-            Humans account using the form below. Then your data will be analyzed!
-            (Depending on your tweet volume and resulting archive size the upload might take a while.)
-          </p>
+          <h3>
+            To upload your tweets&hellip;
+          </h3>
+            <ol>
+            <li>Downloaded the archive you requested as described above</li>
+            <li>Open this zipped archive and <b>extract the <code>tweet.js</code> file from it</b>.</li>
+            <li>Optionally: If your <code>tweet.js</code> file is very big you can make a new zip file only containing that</li>
+            <li>You can now upload the <code>tweet.js</code> to Open Humans account using the form below.</li>
+            </ol>
+            After all of this your data will be analyzed! Depending on your tweet volume and resulting archive size the upload might take a while.
+          <h4>
+            What's in the <code>tweet.js</code> file I'm supposed to upload?
+          </h4>
+            The file contains all of your tweets along with metadata like geolocation,
+            whether it was a reply and to whom, links etc.
+            It does <b>not</b> contain your direct messages, videos, images or anything else.
         </div>
         <div class="col-md-6">
           <div class="panel panel-default">

--- a/users/templates/users/dashboard.html
+++ b/users/templates/users/dashboard.html
@@ -85,11 +85,11 @@
       <div class="panel-body">
         <p>
           {% if has_data %}
-          You want to replace the Twitter archive that is stored on Open Humans with a newer copy?
+          You want to replace the tweets that are stored on Open Humans with a newer copy?
           {% else %}
-          We first need a copy of your Twitter archive loaded on Open Humans to do analysis.
+          We first need a copy of your tweets loaded on Open Humans to do our analysis.
           {% endif %}
-          Just enter the file in the form above and you're good to go.
+          Just upload the <code>tweet.js</code> file from your Twitter data export with form above and you're good to go.
         </p>
         {% include 'users/partials/upload_form.html' %}
       </div>

--- a/users/templates/users/index.html
+++ b/users/templates/users/index.html
@@ -15,13 +15,13 @@
         <div class="col-md-6">
           <h2>How it works</h2>
           <ol>
-            <li><b>Request your Twitter archive from the <a href="https://twitter.com/settings/account">Twitter website</a></b><br>
-              Visit your
-              <a href="https://twitter.com/settings/account">
-                account settings
-              </a> and scroll all the way down. Click on <i>Request your archive</i>.
-              Once the archive is created Twitter will email you with the link to
-              download it.
+            <li><b>Request your Twitter archive from the <a href="https://twitter.com/settings/your_twitter_data">Twitter website</a></b><br>
+              Visit the
+              <a href="https://twitter.com/settings/your_twitter_data">
+                Twitter data page
+              </a> and enter your password to request your data. Generating the
+              data will take Twitter some time. Once it is ready you will
+              get an email from Twitter with a link where you can download the data.
             </li>
             <li><b>Log in or create an Open Humans account</b><br>
               You can upload your Twitter archive into this account once Twitter
@@ -29,7 +29,11 @@
             </li>
             <li><b>Authorize the <font color="#1DA1F2">Tw</font>Arχiv in Open Humans</b><br>
               This authorizes us to deposit your archive into your Open Humans account.</li>
-            <li><b>Upload your archive.</b><br>
+            <li><b>Extract your Tweets from the archive</b><br>
+              Open the zipped archive file that you downloaded from Twitter and
+              extract the <code>tweet.js</code> file from it.
+            </li>
+            <li><b>Upload your tweets.</b><br>
               You will be redirected back to the <font color="#1DA1F2">Tw</font>Arχiv and can then
               upload your archive data.
               You'll be able to

--- a/users/templates/users/partials/upload_form.html
+++ b/users/templates/users/partials/upload_form.html
@@ -16,7 +16,7 @@ function startUpload() {
       replacement =  '<h3>Your Upload started</h3><div class="progress"><div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="45" aria-valuemin="0" aria-valuemax="100" style="width: 45%"></div></div>'
       $("#upload_form").replaceWith('<div id="upload_form">'+replacement+'</div>');
       var xhr = new XMLHttpRequest();
-      var metadata = JSON.stringify({"tags":["twitter","twitter-archive"],"description" : "Twitter archive file"});
+      var metadata = JSON.stringify({"tags":["twitter","twitter-archive","new-twitter-archive"],"description" : "Twitter archive file"});
       xhr.open('POST', "https://www.openhumans.org/api/direct-sharing/project/files/upload/direct/?access_token={{oh_member.access_token}}", true);
       xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
       xhr.send('project_member_id={{oh_member.oh_id}}&filename='+file['name']+'&metadata='+metadata);

--- a/users/templates/users/partials/upload_form.html
+++ b/users/templates/users/partials/upload_form.html
@@ -75,11 +75,11 @@ function startUpload() {
   {% endif %}
   {% csrf_token %}
   <p>
-    <b>Upload Twitter archive file</b><br>
-    (complete zip-file as downloaded)<br>
+    <b>Upload your <code>tweet.js</code> file</b><br>
+    (either uncompressed or as a zip file)<br>
     <input id='file' type="file" name="file" class="btn">
   </p>
-  <input type="button" class="btn btn-primary" value="Upload Twitter archive" onClick="startUpload()"></br></br>
+  <input type="button" class="btn btn-primary" value="Upload Tweets" onClick="startUpload()"></br></br>
   <p>
     <small>The analysis after the upload can take a while. We will message you through
     the <em>Open Humans</em> system once your graphs are ready.</small>


### PR DESCRIPTION
As outlined in #42 the old formats can't be downloaded from Twitter any longer. This PR will allow the upload of the new formats, either as a fully zipped file (not advisable), an unzipped `tweet.js` file or a zipped version of the `tweet.js`. 

Unfortunately Twitter revamped their own JSON storage a bit, so that this was a bit more work than hoped. Nevertheless the data import and analysis scripts should have maintained backwards compatibility so far.  